### PR TITLE
feat: Create action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# rst-substitution-action
-Github action to replace substitutions in rst file.

--- a/README.rst
+++ b/README.rst
@@ -39,3 +39,9 @@ If multiple values need to be defined, use folded block scalar style.
      'name1=value1'
      'name2=value2'
      ...
+
+License
+=======
+
+`MIT
+License <https://github.com/junghoon-vans/rst-substitution-action/blob/main/LICENSE>`__

--- a/README.rst
+++ b/README.rst
@@ -3,3 +3,39 @@ rst-substitution-action
 =======================
 
 Github action to replace substitutions in rst file.
+
+
+Inputs
+======
+
+input-file
+~~~~~~~~~~
+
+**Optional**
+The file path to read contents.
+
+Default: ``./README.rst``
+
+output-file
+~~~~~~~~~~~
+
+**Optional**
+The file path to write contents.
+
+Default: ``input-file``
+
+substitutions
+~~~~~~~~~~~~~
+
+**Required**
+A key-value of substitutions.
+
+If multiple values need to be defined, use folded block scalar style.
+
+
+.. code:: yml
+
+   substitutions: >-
+     'name1=value1'
+     'name2=value2'
+     ...

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,5 @@
+=======================
+rst-substitution-action
+=======================
+
+Github action to replace substitutions in rst file.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,23 @@
+name: 'RST Substitution'
+description: 'Replace substitutions in reStructuredText file'
+author: 'junghoon-vans'
+inputs:
+  input-file:
+    description: 'Input file path to read contents'
+    required: true
+  output-file:
+    description: 'Output file path to write contents'
+    required: true
+  substitutions:
+    description: 'Multiline strings for key-value pair of substitutions'
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: python -m pip install varst
+      shell: bash
+    - run: varst -i ${{ inputs.input-file }} -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,13 @@ description: 'Replace substitutions in reStructuredText file'
 author: 'junghoon-vans'
 inputs:
   input-file:
-    description: 'Input file path to read contents'
+    description: 'The file path to read contents.'
     required: false
   output-file:
-    description: 'Output file path to write contents'
+    description: 'The file path to write contents.'
     required: false
   substitutions:
-    description: 'Multiline strings for key-value pair of substitutions'
+    description: 'A key-value of substitutions.'
     required: true
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -20,19 +20,15 @@ runs:
     - run: python -m pip install varst
       shell: bash
     - run: |
-        if [ "${{ inputs.input-file }}" = "" ] && [ "${{ inputs.output-file }}" = "" ]; then
-          varst ${{ inputs.substitutions }}
+        cmd="varst"
+
+        if [ "${{ inputs.input-file }}" != "" ]; then
+          cmd+=" -i ${{ inputs.input-file }}"
         fi
-        
-        if [ "${{ inputs.input-file }}" != "" ] && [ "${{ inputs.output-file }}" = "" ]; then
-          varst -i ${{ inputs.input-file }} ${{ inputs.substitutions }}
+
+        if [ "${{ inputs.output-file }}" != "" ]; then
+          cmd+=" -o ${{ inputs.output-file }}"
         fi
-        
-        if [ "${{ inputs.input-file }}" = "" ] && [ "${{ inputs.output-file }}" != "" ]; then
-          varst -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
-        fi
-        
-        if [ "${{ inputs.input-file }}" != "" ] && [ "${{ inputs.output-file }}" != "" ]; then
-          varst -i ${{ inputs.input-file }} -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
-        fi
+
+        eval "${cmd} ${{ inputs.substitutions }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -22,11 +22,11 @@ runs:
     - run: |
         cmd="varst"
 
-        if [ "${{ inputs.input-file }}" != "" ]; then
+        if [ -n "${{ inputs.input-file }}" ]; then
           cmd+=" -i ${{ inputs.input-file }}"
         fi
 
-        if [ "${{ inputs.output-file }}" != "" ]; then
+        if [ -n "${{ inputs.output-file }}" ]; then
           cmd+=" -o ${{ inputs.output-file }}"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,10 @@ author: 'junghoon-vans'
 inputs:
   input-file:
     description: 'Input file path to read contents'
-    required: true
+    required: false
   output-file:
     description: 'Output file path to write contents'
-    required: true
+    required: false
   substitutions:
     description: 'Multiline strings for key-value pair of substitutions'
     required: true
@@ -19,5 +19,20 @@ runs:
         python-version: '3.10'
     - run: python -m pip install varst
       shell: bash
-    - run: varst -i ${{ inputs.input-file }} -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
+    - run: |
+        if [ "${{ inputs.input-file }}" = "" ] && [ "${{ inputs.output-file }}" = "" ]; then
+          varst ${{ inputs.substitutions }}
+        fi
+        
+        if [ "${{ inputs.input-file }}" != "" ] && [ "${{ inputs.output-file }}" = "" ]; then
+          varst -i ${{ inputs.input-file }} ${{ inputs.substitutions }}
+        fi
+        
+        if [ "${{ inputs.input-file }}" = "" ] && [ "${{ inputs.output-file }}" != "" ]; then
+          varst -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
+        fi
+        
+        if [ "${{ inputs.input-file }}" != "" ] && [ "${{ inputs.output-file }}" != "" ]; then
+          varst -i ${{ inputs.input-file }} -o ${{ inputs.output-file }} ${{ inputs.substitutions }}
+        fi
       shell: bash


### PR DESCRIPTION
# Feature

Change the `substitutions` in the rst file on the GitHub action.

- If `input-file` is not provided, default value is `README.rst`.
- If `output-file` is not provided, default value is equal to `input-file`. 

# Example workflow

```
name: Update rst file

on:
  pull_request:
  push:
    branches:
      - main

jobs:
  update-rst-file:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: junghoon-vans/rst-substitution-action@main
        with:
          substitutions: 'sub_name=value'
      - uses: stefanzweifel/git-auto-commit-action@v4
```