### PR TITLE
chore: Use commitizen to version control

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,4 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.0.0"
+tag_format = "v$version"

--- a/.github/worklflows/bump-version.yml
+++ b/.github/worklflows/bump-version.yml
@@ -1,0 +1,29 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump_version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: 'Bump version and create changelog with commitizen'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          changelog_increment_filename: body.md
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "body.md"
+          tag_name: "${{ env.REVISION }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## v1 (2022-12-01)
+
+### Feat
+
+- Running action without passing file paths
+- Create action.yml
+
+### Refactor
+
+- Use n operator to check empty options
+- Save command to variable to reduce if statement

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Refer example workflow if you want to replace substitutions in ``README.rst`` an
    steps:
      - uses: actions/checkout@v3
      - name: Replace substitution
-     - uses: junghoon-vans/varst-action@main
+     - uses: junghoon-vans/varst-action@v1
        with:
          substitutions: "name=value"
      - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Changes
---

- Add `.cz.toml` for commitizen configuration.
- Add bump-version workflow.
- Create `CHANGELOG.md`.
- Update `README.rst` to satisfy workflow version to `v1`.