### PR TITLE
fix: no such file on requirements

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,6 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-        cache: 'pip'
     - run: pip install varst=="${{ inputs.version }}"
       shell: bash
     - run: |


### PR DESCRIPTION
Error
---

![error log](https://user-images.githubusercontent.com/44942700/209295102-3dca08dc-7c79-45db-a3a4-069e65859524.png)

If there is no destination to cache, the following error occurs,

Solution
---

The cache option is not used for our actions, so remove it.